### PR TITLE
Validation of users (UWUM members)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ Configure provider: add a full path to the certificate, also all the UWUM URLs. 
             'CERT': path.join(path.dirname(path.abspath(__file__)), 'uwum.pem'),
             'SCOPE': ['authentication', 'notify_email', 'post', 'rate', 'vote'],
             'AUTHORIZE_URL': 'https://...',
+            'VALIDATE_URL': 'https://...',
             'ACCESS_TOKEN_URL': 'https://...',
-            'PROFILE_URL': 'https://...',
             'NOTIFY_EMAIL_URL': 'https://...',
         },
     }

--- a/allauth_uwum/views.py
+++ b/allauth_uwum/views.py
@@ -35,19 +35,19 @@ class UWUMAdapter(OAuth2Adapter):
 
     def complete_login(self, request, app, access_token, **kwargs):
         """Complete the social login process."""
-        headers = self._make_request_headers(access_token)
-        params = {'include_member': True}
-        response = post(
-            self.validate_url,
-            headers=headers,
-            params=params,
-        ).json()
+        response = self.validate_user(access_token).json()
 
         if app_settings.QUERY_EMAIL and response['member']:
             # Email address used for notifications will be a default user email
             response['member']['email'] = self.get_notify_email(access_token)
 
         return self.get_provider().sociallogin_from_response(request, response)
+
+    def validate_user(self, access_token):
+        """Validate the user."""
+        headers = self._make_request_headers(access_token)
+        params = {'include_member': True}
+        return post(self.validate_url, headers=headers, params=params)
 
     def _make_request_headers(self, access_token):
         """Make the request headers by adding the bearer access token."""

--- a/allauth_uwum/views.py
+++ b/allauth_uwum/views.py
@@ -1,6 +1,6 @@
 """All views of the UWUM provider."""
 
-from requests import get
+from requests import get, post
 
 from django.core.urlresolvers import reverse
 
@@ -23,8 +23,8 @@ class UWUMAdapter(OAuth2Adapter):
     provider_id = UWUMProvider.id
 
     authorize_url = UWUMProvider.settings.get('AUTHORIZE_URL')
+    validate_url = UWUMProvider.settings.get('VALIDATE_URL')
     access_token_url = UWUMProvider.settings.get('ACCESS_TOKEN_URL')
-    profile_url = UWUMProvider.settings.get('PROFILE_URL')
     notify_email_url = UWUMProvider.settings.get('NOTIFY_EMAIL_URL')
 
     def get_notify_email(self, access_token):
@@ -37,7 +37,11 @@ class UWUMAdapter(OAuth2Adapter):
         """Complete the social login process."""
         headers = self._make_request_headers(access_token)
         params = {'include_member': True}
-        response = get(self.profile_url, headers=headers, params=params).json()
+        response = post(
+            self.validate_url,
+            headers=headers,
+            params=params,
+        ).json()
 
         if app_settings.QUERY_EMAIL and response['member']:
             # Email address used for notifications will be a default user email


### PR DESCRIPTION
Users (UWUM members) are now being validated using the specific UWUM "validate" endpoint. The method for validation is also available for use externally via the UWUM OAuth2 adapter, e.g.:

```python
from allauth_uwum.views import UWUMAdapter, UWUMView

# UWUM view should have current request and adapter attached
view = UWUMView()
view.request = request
view.adapter = UWUMAdapter(view.request)

# We can now use the UWUM access token to validate the user
response = view.adapter.validate_user(access_token)
# Our response will contain some basic personal information (UWUM member ID and name)
member = response.json().get('member')
```
